### PR TITLE
Unflattened data in preprocessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ node_modules
 
 # Visual Studio
 .vscode
+test.py
 
 # dataset
 data

--- a/CNN/model.py
+++ b/CNN/model.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn as nn
 
 class CNN(nn.Module):
@@ -8,26 +9,28 @@ class CNN(nn.Module):
         # input is of size (batch_size, 30, 216, 1)
         # applying 32 kernels of size of (4,10)
         self.conv1 = nn.Sequential(
-                    nn.Conv2d(in_channels = n_mfcc, out_channels = 32, kernel_size = (4,10)),
+                    nn.Conv2d(in_channels=n_mfcc, out_channels=32, kernel_size=(4,10)),
                     nn.BatchNorm2d(4),
                     nn.ReLU(),
                     nn.MaxPool2d(4),
-                    nn.Dropout(p = 0.2))
+                    nn.Dropout(p=0.2))
         self.output = nn.Sequential(
-                        nn.Dropout( p =0.2),
+                        nn.Dropout(p=0.2),
                         nn.BatchNorm2d(4),
                         nn.ReLU(),
                         nn.Dropout(p=0.2)
                         )
-
+    
     def forward(self, x):
+        x = torch.reshape(x, (x.size()[0], 30, 216))
+        print(x.size())
         x = self.conv1(x)
         x = self.conv1(x)
         x = self.conv1(x)
         x = self.conv1(x)
-        self.linear =  nn.Linear(x.size[0],64)
+        self.linear =  nn.Linear(x.size[0], 64)
         x = self.linear(x)
         x = self.output(x)
-        self.end = nn.Sequential(nn.Linear(x.size[0], 16),nn.Softmax())
+        self.end = nn.Sequential(nn.Linear(x.size[0], 16), nn.Softmax())
         x = self.end(x)
         return x

--- a/baseline/model.py
+++ b/baseline/model.py
@@ -17,14 +17,14 @@ class MLP(nn.Module):
         if len(hidden_layers) == 0:
             self.mlp = nn.Sequential(
                 nn.Linear(input_size, output_size),
-                nn.Softmax()
+                nn.Softmax(dim=1)
             )
         elif len(hidden_layers) == 1:
             self.mlp = nn.Sequential(
                 nn.Linear(input_size, hidden_layers[0]),
                 nn.ReLU(),
                 nn.Linear(hidden_layers[-1], output_size),
-                nn.Softmax()
+                nn.Softmax(dim=1)
             )
         else:
             Hidden = []
@@ -37,13 +37,13 @@ class MLP(nn.Module):
                 nn.ReLU(),
                 *Hidden,
                 nn.Linear(hidden_layers[-1], output_size),
-                nn.Softmax()
+                nn.Softmax(dim=1)
             )
         
         #print(self.mlp)
     
     def forward(self, x):
-        return self.mlp(x)
+        return self.mlp(x.view(x.size(0), -1))
 
 class Average(nn.Module):
 
@@ -57,8 +57,6 @@ class Average(nn.Module):
         self.fc = nn.Linear(input_size, output_size)
     
     def forward(self, x):
-        #x = torch.reshape(x, (x.size()[0], 30, 216))
-        #average = x.mean(1)
-        x = torch.reshape(x, (x.size()[0], 216, 30))
-        average = x.mean(2)
-        return nn.Softmax( self.fc(average).squeeze() )
+        print(x.size())
+        average = x.mean(1)
+        return nn.Softmax(dim=1)(self.fc(average).squeeze())

--- a/data_handling/load_data.py
+++ b/data_handling/load_data.py
@@ -28,27 +28,27 @@ def get_data(overfit=False):
 
 def one_hot_encode(df_label):
     
-    Mapping = json.load(open(f"{ROOT}/data/Mapping.json", "r"))
+    Metadata = json.load(open(f"{ROOT}/data/Metadata.json", "r"))
     
     tensor_label_ints = torch.from_numpy( df_label.values ).transpose(0, 1)
-    tensor_labels_onehot = torch.zeros(tensor_label_ints.shape[1], len(Mapping))
+    tensor_labels_onehot = torch.zeros(tensor_label_ints.shape[1], len(Metadata["mapping"]))
     tensor_labels_onehot[range(tensor_labels_onehot.shape[0]), tensor_label_ints] = 1
 
     return tensor_labels_onehot
 
-def load_data(batch_size, overfit=False):
+def load_data(batch_size, n_mfcc, audio_length, overfit=False):
 
     train_data, train_label, valid_data, valid_label, test_data, test_label = get_data(overfit=overfit)
     
-    train_data = torch.from_numpy( train_data.to_numpy() )
+    train_data = torch.from_numpy( train_data.to_numpy() ).reshape(-1, n_mfcc, audio_length)
     train_label = torch.from_numpy( train_label.to_numpy() ).squeeze()
     #train_label = one_hot_encode(train_label)
     
-    valid_data = torch.from_numpy( valid_data.to_numpy() )
+    valid_data = torch.from_numpy( valid_data.to_numpy() ).reshape(-1, n_mfcc, audio_length)
     valid_label = torch.from_numpy( valid_label.to_numpy() ).squeeze()
     #valid_label = one_hot_encode(valid_label)
 
-    test_data = torch.from_numpy( test_data.to_numpy() )
+    test_data = torch.from_numpy( test_data.to_numpy() ).reshape(-1, n_mfcc, audio_length)
     test_label = torch.from_numpy( test_label.to_numpy() ).squeeze()
     #test_label = one_hot_encode(test_label)
     
@@ -60,6 +60,8 @@ def load_data(batch_size, overfit=False):
 
 if __name__ == "__main__":
     
+    Metadata = json.load(open(f"{ROOT}/data/Metadata.json", "r"))
+
     """
     train_data, train_label, valid_data, valid_label = get_data()
     print(valid_data)
@@ -72,5 +74,11 @@ if __name__ == "__main__":
     print(overfit_label)
     """
 
-    train_iter, valid_iter, test_iter = load_data(64)
-    print(train_iter)
+    train_iter, valid_iter, test_iter = load_data(64, Metadata["n_mfcc"], Metadata["audio_length"])
+    for i, (batch, labels) in enumerate(train_iter):
+        if i > 2:
+            break
+        print(batch)
+        print(batch.size())
+        print(labels)
+        print()

--- a/main.py
+++ b/main.py
@@ -110,20 +110,52 @@ def training_loop(model, train_iter, valid_iter, test_iter, optimizer, loss_fnc,
 
 def main():
     
-    #model = MLP(input_size=30*216, output_size=16)
-    #model = Average(input_size=216, output_size=16)
-    model = CNN(30)
+    Metadata = json.load(open(f"./data/Metadata.json", "r"))
+    n_mfcc = Metadata["n_mfcc"]
+    audio_length = Metadata["audio_length"]
+    n_classes = len(Metadata["mapping"])
 
-    hyperparameters = {
-        "optimizer" : torch.optim.Adam,
-        "loss_fnc" : nn.CrossEntropyLoss(),
-        "epochs" : 200,
-        "batch_size" : 64,
-        "lr" : 0.001,
-        "eval_every" : 10
-    }
+    #model_name = "mlp"
+    model_name = "average"
+    #model_name = "cnn"
 
-    train_iter, valid_iter, test_iter = load_data(hyperparameters["batch_size"], overfit=True)
+    model = None
+    hyperparameters = {}
+
+    if model_name.lower() == "mlp":
+        model = MLP(input_size=n_mfcc*audio_length, output_size=n_classes)
+        hyperparameters = {
+            "optimizer" : torch.optim.Adam,
+            "loss_fnc" : nn.CrossEntropyLoss(),
+            "epochs" : 100,
+            "batch_size" : 64,
+            "lr" : 0.001,
+            "eval_every" : 10
+        }
+    elif model_name.lower() == "average":
+        model = Average(input_size=audio_length, output_size=n_classes)
+        hyperparameters = {
+            "optimizer" : torch.optim.Adam,
+            "loss_fnc" : nn.CrossEntropyLoss(),
+            "epochs" : 500,
+            "batch_size" : 64,
+            "lr" : 0.1,
+            "eval_every" : 10
+        }
+    elif model_name.lower() == "cnn":
+        model = CNN(30)
+        hyperparameters = {
+            "optimizer" : torch.optim.Adam,
+            "loss_fnc" : nn.CrossEntropyLoss(),
+            "epochs" : 100,
+            "batch_size" : 64,
+            "lr" : 0.1,
+            "eval_every" : 10
+        }
+    else:
+        raise ValueError(f"Model '{model_name}' does not exist")
+
+    train_iter, valid_iter, test_iter = load_data(hyperparameters["batch_size"], n_mfcc, audio_length, overfit=True)
     training_loop(model, train_iter, valid_iter, test_iter, **hyperparameters)
 
 if __name__ == "__main__":


### PR DESCRIPTION
When you called `load_data()`, instead of data coming in through the iterators as `[batch size, 30*216]` it comes as `[batch size, 30, 216]`. This is to ensure we don't accidentally unflatten the tensor incorrectly. It needed to be flattened initially to efficiently store in the .tsv files